### PR TITLE
feat: 新增 af_info 函數並增加單元測試

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -41,7 +41,8 @@ def af_info(log_path: Path) -> None:
             if len(parts) >= 2:
                 jax_versions.append(f"{parts[0]} {parts[1]}")
 
-        jax_summary = ", ".join(jax_versions)
+        jax_summary = ", ".join(jax_versions) if jax_versions else "N/A"
+
     except FileNotFoundError:
         log_message("Error: pip is not available in this environment.", log_path)
         return

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -24,7 +24,6 @@ def af_info(log_path: Path) -> None:
     Parameters:
         log_path (Path): Path to the log file where information will be written.
     """
-    from .main import log_message
 
     try:
         result = subprocess.run(

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,3 +1,6 @@
+import os
+import sys
+import subprocess
 from pathlib import Path
 
 
@@ -12,3 +15,48 @@ def log_message(message: str, log_path: Path) -> None:
     print(message)
     with open(log_path, "a") as f:
         f.write(message + "\n")
+
+
+def af_info(log_path: Path) -> None:
+    """
+    Collect and log Python environment information related to AlphaFold.
+
+    Parameters:
+        log_path (Path): Path to the log file where information will be written.
+    """
+    from .main import log_message
+
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "list"],
+            capture_output=True, 
+            text=True,
+            check=True
+        )
+
+        jax_lines = [line for line in result.stdout.splitlines() if "jax" in line.lower()]
+        jax_versions = []
+
+        for line in jax_lines:
+            parts = line.split()
+            if len(parts) >= 2:
+                jax_versions.append(f"{parts[0]} {parts[1]}")
+
+        jax_summary = ", ".join(jax_versions)
+    except FileNotFoundError:
+        log_message("Error: pip is not available in this environment.", log_path)
+        return
+
+    tf_deterministic_ops = os.environ.get("TF_DETERMINISTIC_OPS", "N/A")
+    tf_unified_memory = os.environ.get("TF_FORCE_UNIFIED_MEMORY", "N/A")
+    xla_fraction = os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", "N/A")
+
+    log_message("==== AlphaFold Environment Information: ====", log_path)
+    log_message(f"Python version: {sys.version}", log_path)
+    log_message(f"JAX versions: {jax_summary}", log_path)
+    log_message(f"TF_DETERMINISTIC_OPS: {tf_deterministic_ops}", log_path)
+    log_message(f"TF_FORCE_UNIFIED_MEMORY: {tf_unified_memory}", log_path)
+    log_message(f"XLA_PYTHON_CLIENT_MEM_FRACTION: {xla_fraction}", log_path)
+    log_message(f"Log file path: {log_path}", log_path)
+    log_message("AlphaFold environment information collected successfully.", log_path)
+    log_message("==== End of Environment Information ====", log_path)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
+import os
+from unittest import mock
 from pathlib import Path
-from scripts.main import log_message
+from scripts.main import log_message, af_info
 
 def test_log_message(tmp_path):
     # Arrange
@@ -12,3 +14,23 @@ def test_log_message(tmp_path):
     # Assert
     content = log_file.read_text()
     assert message in content
+
+
+@mock.patch("scripts.main.subprocess.run")
+def test_af_info(mock_run, tmp_path):
+    # Arrange
+    log_file = tmp_path / "env.log"
+    fake_output = "jax 0.4.21\njaxlib 0.4.21"
+    mock_run.return_value.stdout = fake_output
+
+    os.environ["TF_DETERMINISTIC_OPS"] = "1"
+    os.environ["TF_FORCE_UNIFIED_MEMORY"] = "1"
+    os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = "0.9"
+
+    # Act
+    af_info(log_file)
+
+    # Assert
+    content = log_file.read_text()
+    assert "jax 0.4.21" in content
+    assert "jaxlib 0.4.21" in content

--- a/uv.lock
+++ b/uv.lock
@@ -10,8 +10,17 @@ dependencies = [
     { name = "pytest" },
 ]
 
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
-requires-dist = [{ name = "pytest", specifier = ">=8.3.5" }]
+requires-dist = [
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest", marker = "extra == 'dev'" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## 變更摘要

此提取請求引入了一個新的函式 `af_info`，用於收集並記錄與 AlphaFold 相關的 Python 環境資訊。它還包含一個針對新函式的單元測試。這些變更包括新增必要的匯入、實作 `af_info` 函式、為其建立測試案例，以及更新 `uv.lock` 檔案以反映依賴項的變更。

### 重點

* **新函式：`af_info`**: 新增了一個函式 `af_info` 到 `scripts/main.py`，用於收集並記錄與 AlphaFold 相關的 Python 環境資訊，包括 Python 版本、JAX 版本和環境變數。
* **`af_info` 的單元測試**: 新增了一個單元測試 `test_af_info` 到 `tests/test_main.py`，用於驗證 `af_info` 函式的功能，包括模擬子進程呼叫並斷言日誌檔案的內容。
* **依賴項管理**: `uv.lock` 檔案已更新，以管理 `pytest` 依賴項，為開發新增了可選的依賴項和元資料。

## 變更日誌

* **scripts/main.py**
  * 新增了 `os`、`sys` 和 `subprocess` 的匯入。
  * 實作了 `af_info` 函式以收集並記錄 AlphaFold 環境資訊。
* **tests/test_main.py**
  * 新增了 `os` 和 `mock` 從 `unittest` 的匯入。
  * 新增了一個針對 `af_info` 函式的單元測試 `test_af_info`，模擬子進程呼叫並斷言日誌檔案的內容。
* **uv.lock**
  * 在 `dev` 額外功能下新增了 `pytest` 的可選依賴項。
  * 更新了元資料，將 `pytest` 作為帶有 `dev` 額外功能標記的必要依賴項包含在內，並新增了 `provides-extras = ["dev"]`。