### PR TITLE
feat: 增加 AlphaFold2 推論支持和更新 README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 wheels/
 *.egg-info
+output
 
 # Virtual environments
 .venv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# 🧬 AlphaFold Automation Runner 
+
+🚀 Designed for run AlphaFold 2 across different GPUs environment. Automatically summarize the benchmark data and environment information.
+
+---
+
+## 📦 Features
+
+- ✅ Command-line interface built with `argparse`
+- ✅ TDD-first workflow using `pytest`
+- ✅ Modular codebase with SOLID principles
+- ✅ Supports mock simulation (no AF2 required)
+- ✅ Optional support for external AlphaFold2 environment
+- ✅ CI-ready with `GitHub Actions` + `uv` + `mypy` + `ruff`
+
+---
+
+## 🛠️ Installation
+
+> Requires Python 3.12+
+
+```bash
+git clone https://github.com/yourname/alphafold-runner.git
+cd alphafold-runner
+
+# Using uv to manage the project environment
+uv pip install -e ".[dev]"
+```
+
+---
+
+## 🧪 Example: Running in Mock Mode (No AF2 required)
+
+```bash
+cat > input.fasta << EOF
+>seq1
+ACDEFGHIK
+>seq2
+LMNPQRSTVWY
+EOF
+```
+
+```bash
+alphafold-runner \
+  --input input.fasta \
+  --backend mock \
+  --log result.log
+```
+
+### ✅ Sample Output
+
+```
+== AlphaFold 2 Runner ==
+Input file: input.fasta
+Run mode: cpu
+Log file: result.log
+🧪 Simulating AlphaFold inference...
+✅ Mock inference complete (seq_len=20)
+```
+
+---
+
+## 🧾 Log Output
+
+```bash
+cat result.log
+```
+
+```
+[2024-03-31 22:15:01] Fasta file input.fasta exists.
+[2024-03-31 22:15:01] 🧪 Simulating AlphaFold inference...
+[2024-03-31 22:15:02] ✅ Mock inference complete (seq_len=20)
+```
+
+---
+
+## 🧬 Running in External Mode (AlphaFold2 Integration)
+
+> You must provide a Python 3.10 environment and AF2 runner script.
+
+```bash
+alphafold-runner \
+  --input input.fasta \
+  --backend external \
+  --af2-python /opt/af2_env/bin/python3.10 \
+  --af2-script /home/user/alphafold/run_alphafold.py \
+  --output-dir results \
+  --log af2.log
+```
+
+---
+
+## 🧪 Running Tests
+
+```bash
+pytest -v
+```
+
+---
+
+## ⚙️ Development Tools
+
+| Tool      | Purpose                |
+|-----------|------------------------|
+| `pytest`  | Unit testing           |
+| `mypy`    | Type checking          |
+| `ruff`    | Linting & formatting   |
+| `uv`      | Dependency management  |
+
+---
+
+## 📂 Project Structure
+
+```
+scripts/
+├── main.py           # CLI entry point
+├── inference.py      # Inference stubs (mock + external)
+├── log_utils.py      # Logging + file checks
+├── env_utils.py      # Platform detection
+├── gpu_detect.py     # GPU backend detection
+
+tests/
+├── test_cli.py
+├── test_inference.py
+├── test_env_utils.py
+└── data/
+    └── multiseq.fasta
+```
+
+---
+
+## 📄 License
+
+MIT License © 2025 Your Name

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -55,5 +55,5 @@ def run_alphafold_external(
         )
         log_message("✅ AlphaFold2 process completed.", log_path)
     except subprocess.CalledProcessError as e:
-        log_message(f"❌ AlphaFold2 failed with return code {e.returncode}", log_path)
+        log_message(f"❌ AlphaFold2 failed with return code {e.returncode}\n{e.stderr.decode()}", log_path)
         raise

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import time
+import pdb
+from scripts.log_utils import log_message
+from scripts.log_utils import check_required_file
+
+def run_inference(input_fasta: Path, log_path: Path) -> None:
+    """
+    Simulate AlphaFold inference process.
+
+    Parameters:
+        input_fasta (Path): The path to input FASTA file.
+        log_path (Path): The path to log file.
+    """
+    check_required_file(input_fasta)
+
+    log_message("Simulating AlphaFold inference...", log_path)
+
+    #time.sleep(1)  # simulate computation
+
+    lines = input_fasta.read_text().splitlines()
+    seq_lines = [line for line in lines if not line.startswith(">")]
+    seq = "".join(seq_lines)
+    seq_length = len(seq)
+
+    log_message(f"Mock inference complete (seq_len={seq_length})", log_path)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -44,6 +44,13 @@ def run_alphafold_external(
         af2_script (Path): Path to run_alphafold.py or main.py
         log_path (Path): Log file path
     """
+    if not af2_python.exists():
+        raise FileNotFoundError(f"AlphaFold2 Python interpreter not found: {af2_python}")
+
+    if not af2_script.exists():
+        raise FileNotFoundError(f"AlphaFold2 script not found: {af2_script}")
+
+    log_message(f"🧪 Calling AlphaFold2 external process...", log_path)
     log_message(f"🧪 Calling AlphaFold2 external process...", log_path)
 
     try:

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import time
 import pdb
+import subprocess
 from scripts.log_utils import log_message
 from scripts.log_utils import check_required_file
 
@@ -24,3 +25,35 @@ def run_inference(input_fasta: Path, log_path: Path) -> None:
     seq_length = len(seq)
 
     log_message(f"Mock inference complete (seq_len={seq_length})", log_path)
+
+
+def run_alphafold_external(
+        input_fasta: Path,
+        output_dir: Path,
+        af2_python: Path,
+        af2_script: Path,
+        log_path: Path
+    ) -> None:
+    """
+    Simulate invoking AlphaFold 2 via subprocess using a different Python environment.
+
+    Parameters:
+        input_fasta (Path): Input FASTA file
+        output_dir (Path): Directory to store output
+        af2_python (Path): Path to AlphaFold2's python executable (3.10)
+        af2_script (Path): Path to run_alphafold.py or main.py
+        log_path (Path): Log file path
+    """
+    log_message(f"🧪 Calling AlphaFold2 external process...", log_path)
+
+    try:
+        subprocess.run(
+            [ str(af2_python), str(af2_script),
+                "--fasta", str(input_fasta),
+                "--output_dir", str(output_dir)],
+            check=True
+        )
+        log_message("✅ AlphaFold2 process completed.", log_path)
+    except subprocess.CalledProcessError as e:
+        log_message(f"❌ AlphaFold2 failed with return code {e.returncode}", log_path)
+        raise

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -38,8 +38,8 @@ def main() -> None:
     parser.add_argument(
         "--log", 
         type=Path, 
-        default= "output" / Path("run.log"), 
-        help="Path to the log file, default: ./run.log"
+        default= Path("output") / Path("run.log"), 
+        help="Path to the log file, default: ./output/run.log"
     )
 
     parser.add_argument(
@@ -83,6 +83,9 @@ def main() -> None:
     setup_platform(args.mode)
 
     # Log the environment information
+    if args.log is None:
+        args.log = Path("output") / Path("run.log")
+    args.log.parent.mkdir(parents=True, exist_ok=True)
     af_info(args.log)
 
     if args.backend == "mock":

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,9 +1,11 @@
 import argparse
 import sys
+import datetime
 from pathlib import Path
 from typing import NoReturn
 from scripts.env_utils import af_info, setup_platform
 from scripts.log_utils import check_required_file
+from scripts.inference import run_inference, run_alphafold_external
 
 
 class CustomArgParser(argparse.ArgumentParser):
@@ -36,8 +38,35 @@ def main() -> None:
     parser.add_argument(
         "--log", 
         type=Path, 
-        default=Path("run.log"), 
+        default= "output" / Path("run.log"), 
         help="Path to the log file, default: ./run.log"
+    )
+
+    parser.add_argument(
+        "--backend",
+        type=str,
+        choices=["mock", "external"],
+        default="mock",
+        help="Inference backend: mock (default) or external"
+    )
+
+    parser.add_argument(
+        "--af2-python",
+        type=Path,
+        help="Path to Python 3.10 interpreter for AlphaFold2"
+    )
+
+    parser.add_argument(
+        "--af2-script",
+        type=Path,
+        help="Path to AlphaFold2 run script"
+    )
+
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,  # fallback to current directory
+        help="Directory to store AlphaFold2 outputs. Default: ./output/<timestamp>"
     )
 
     args = parser.parse_args()
@@ -55,6 +84,30 @@ def main() -> None:
 
     # Log the environment information
     af_info(args.log)
+
+    if args.backend == "mock":
+        run_inference(args.input, args.log)
+
+    elif args.backend == "external":
+        if not args.af2_python or not args.af2_script:
+            raise ValueError("External mode requires --af2-python and --af2-script")
+
+        # Check if the provided paths exist
+        output_dir = args.output_dir
+        if output_dir is None:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            output_dir = Path("output") / timestamp
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        run_alphafold_external(
+            input_fasta=args.input,
+            output_dir=output_dir,
+            af2_python=args.af2_python,
+            af2_script=args.af2_script,
+            log_path=args.log
+        )
+    else:
+        raise ValueError(f"Unknown backend: {args.backend}")
 
     # Log the successful setup
     print("Setup complete. Ready to run AlphaFold (not yet implemented).")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,6 +1,6 @@
 import argparse
 import sys
-import datetime
+from datetime import datetime
 from pathlib import Path
 from typing import NoReturn
 from scripts.env_utils import af_info, setup_platform

--- a/tests/data/multi_seq.fasta
+++ b/tests/data/multi_seq.fasta
@@ -1,0 +1,4 @@
+>3I3Z_1|Chain A|Insulin A chain|Homo sapiens (9606)
+GIVEQCCTSICSLYQLENYCN
+>3I3Z_2|Chain B|Insulin B chain|Homo sapiens (9606)
+FVNQHLCGSHLVEALYLVCGERGFFYTPKA

--- a/tests/data/single_seq.fasta
+++ b/tests/data/single_seq.fasta
@@ -1,0 +1,2 @@
+>1UAO_1|Chain A|Chignolin|null
+GYDPETGTWG

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 import pytest
+import pdb
+from unittest.mock import patch, call
 from pathlib import Path
 from scripts.main import main
 
@@ -67,3 +69,97 @@ def test_cli_file_not_exist(monkeypatch, capsys, tmp_path):
 
     # Assert
     assert "Error: Missing required file" in str(excinfo.value)
+
+
+@patch("scripts.inference.subprocess.run")
+def test_cli_backend_external(mock_subprocess_run, tmp_path, monkeypatch, capsys):
+    # Arrange: 
+    input_path = Path("tests/data/single_seq.fasta")
+    fasta_text = input_path.read_text()
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(fasta_text)
+
+    af2_py = tmp_path / "fake_af2_python" # external fake python binary
+    af2_py.write_text("#!/usr/bin/env python3.10\n")
+    af2_script = tmp_path / "fake_af2_script.py"
+    af2_script.write_text("# dummy script")
+
+    log_file = tmp_path / "run.log"
+    output_dir = tmp_path / "output"
+
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner",
+        "--input", str(fasta_file),
+        "--backend", "external",
+        "--af2-python", str(af2_py),
+        "--af2-script", str(af2_script),
+        "--log", str(log_file),
+        "--output-dir", str(output_dir)
+    ])
+
+    # Act: 執行 CLI main
+    main()
+
+    # Assert: subprocess.run
+    excepted_call = call([
+        str(af2_py),
+        str(af2_script),
+        "--fasta", str(fasta_file),
+        "--output_dir", str(output_dir)
+    ], check=True)
+    assert excepted_call in mock_subprocess_run.call_args_list
+
+    args_passed = mock_subprocess_run.call_args[0][0]
+    assert str(fasta_file) in args_passed
+    assert str(af2_py) in args_passed
+    assert str(af2_script) in args_passed
+
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "✅ AlphaFold2 process completed" in content
+
+
+@patch("scripts.inference.subprocess.run")
+def test_cli_external_missing_af2_python(mock_subprocess_run, tmp_path, monkeypatch):
+    # Arrange:
+    input_path = Path("tests/data/single_seq.fasta")
+    fasta_text = input_path.read_text()
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(fasta_text)
+
+    script = tmp_path / "fake_af2_script.py"
+    script.write_text("# dummy")
+
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner",
+        "--input", str(fasta_file),
+        "--backend", "external",
+        "--af2-script", str(script)
+    ])
+
+    # Act & Assert:
+    with pytest.raises(ValueError, match="requires --af2-python"):
+        main()
+
+
+@patch("scripts.inference.subprocess.run")
+def test_cli_external_missing_af2_script(mock_subprocess_run, tmp_path, monkeypatch):
+    # Arrange:
+    input_path = Path("tests/data/single_seq.fasta")
+    fasta_text = input_path.read_text()
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(fasta_text)
+
+    af2_python = tmp_path / "fake_af2_python"
+    af2_python.write_text("# dummy python")
+
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner",
+        "--input", str(fasta_file),
+        "--backend", "external",
+        "--af2-python", str(af2_python)
+    ])
+
+    # Act & Assert:
+    with pytest.raises(ValueError, match="requires --af2-python and --af2-script"):
+        main()

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,48 @@
+import pytest
+from scripts.inference import run_inference
+from pathlib import Path
+
+def test_run_inference_success(tmp_path):
+    # Arrange
+    input_path = Path("tests/data/single_seq.fasta")
+    fasta_text = input_path.read_text()
+    fasta_file = tmp_path / "single.fasta"
+    fasta_file.write_text(fasta_text)
+    log_file = tmp_path / "single.txt"
+
+    # Act
+    run_inference(fasta_file, log_file)
+
+    # Assert
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "Mock inference complete" in content
+    assert "seq_len=10" in content # exmpale sequence length is 10 
+
+
+def test_run_inference_multiseq(tmp_path):
+    # Arrange
+    input_path = Path("tests/data/multi_seq.fasta")
+    fasta_text = input_path.read_text()
+    fasta_file = tmp_path / "multi.fasta"
+    fasta_file.write_text(fasta_text)
+    log_file = tmp_path / "multi.log"
+
+    # Act
+    run_inference(fasta_file, log_file)
+
+    # Assert
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "Mock inference complete" in content
+    assert "seq_len=51" in content # example sequence length is 51
+
+
+def test_run_inference_missing_file(tmp_path):
+    # Arrange
+    fasta_file = tmp_path / "not_exist.fasta"
+    log_file = tmp_path / "log.txt"
+
+    # Act & Assert
+    with pytest.raises(FileNotFoundError, match="Missing required file"):
+        run_inference(fasta_file, log_file)


### PR DESCRIPTION
## 變更摘要

此 Pull Request 引入了對 AlphaFold2 推論的支援，包含用於測試的模擬後端以及用於整合現有 AlphaFold2 安裝的外部後端。它也更新了 README，提供了關於如何使用新功能的說明。變更包括新增了用於指定後端、AlphaFold2 Python 直譯器和腳本路徑的命令列參數。此外，測試也已更新，包含對外部後端的測試。

### 重點

*   **AlphaFold2 推論支援**: 新增對 AlphaFold2 推論的支援，同時支援模擬和外部後端。
*   **命令列參數**: 引入新的命令列參數，用於指定推論後端、AlphaFold2 Python 直譯器和腳本路徑。
*   **README 更新**: 更新 README，提供關於如何使用新的 AlphaFold2 推論功能的說明。
*   **外部後端測試**: 新增對外部 AlphaFold2 後端的測試，包括對遺失參數的檢查。

## 變更日誌

<details>
<summary>點擊此處以查看變更日誌</summary>

*   **.gitignore**
    *   新增 `output/` 到 `.gitignore` 檔案，以防止追蹤 `output` 目錄。
*   **README.md**
    *   新增一個全面的 README 檔案，詳細介紹專案、其功能、安裝說明、使用範例（模擬和外部模式）、測試、開發工具、專案結構和授權資訊。
*   **scripts/inference.py**
    *   引入 `run_inference` 函數來模擬 AlphaFold 推論，從輸入的 FASTA 檔案計算序列長度。
    *   新增 `run_alphafold_external` 函數，透過 subprocess 呼叫 AlphaFold2，使用指定的 Python 環境和腳本。
*   **scripts/main.py**
    *   匯入 `datetime` 和新的推論函數。
    *   新增命令列參數，用於指定推論後端 (`--backend`)、AlphaFold2 Python 直譯器 (`--af2-python`)、AlphaFold2 腳本路徑 (`--af2-script`) 和輸出目錄 (`--output-dir`)。
    *   實作邏輯，根據選定的後端和提供的參數，執行模擬推論或外部 AlphaFold2 處理程序。
    *   將預設的日誌檔路徑設定為 `output/run.log`。
*   **tests/data/multi_seq.fasta**
    *   新增一個包含多個序列的 FASTA 檔案，用於測試目的。
*   **tests/data/single_seq.fasta**
    *   新增一個包含單個序列的 FASTA 檔案，用於測試目的。
*   **tests/test_cli.py**
    *   匯入 `pdb` 和模擬工具。
    *   新增對外部後端的測試，包括成功執行和處理遺失的參數 (`--af2-python`, `--af2-script`)。
*   **tests/test_inference.py**
    *   新增對 `run_inference` 函數的測試，包括使用單個和多個序列成功執行，以及處理遺失的輸入檔案。

</details>