### PR TITLE
feat: 增加輸出目錄準備和日誌工具

### DIFF
--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -21,4 +21,9 @@ def prepare_output_dir(output_dir: Path, log_path: Path | None = None) -> None:
             log_message(f"Error creating output directory {output_dir}: {e}", log_path)
             raise
     else:
-        log_message(f"Reusing existing output directory: {output_dir}", log_path)
+        # Handle write permissions error
+        try:
+            log_message(f"Reusing existing output directory: {output_dir}", log_path)
+        except OSError as e:
+            log_message(f"Error reusing output directory {output_dir}: {e}", log_path)
+            raise

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from scripts.log_utils import log_message
+
+def prepare_output_dir(output_dir: Path, log_path: Path | None = None) -> None:
+    """
+    Prepare the output directory for AlphaFold inference.
+
+    If the directory does not exist, it will be created.
+    If it exists, it will be emptied (files and subdirectories deleted).
+    Optionally logs actions if log_path is provided.
+
+    Parameters:
+        output_dir (Path): The directory to prepare.
+        log_path (Path | None): Optional path to a log file.
+    """
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)    
+        log_message(f"Created output directory: {output_dir}", log_path)
+    else:
+        log_message(f"Reusing existing output directory: {output_dir}", log_path)

--- a/scripts/io_utils.py
+++ b/scripts/io_utils.py
@@ -14,7 +14,11 @@ def prepare_output_dir(output_dir: Path, log_path: Path | None = None) -> None:
         log_path (Path | None): Optional path to a log file.
     """
     if not output_dir.exists():
-        output_dir.mkdir(parents=True, exist_ok=True)    
-        log_message(f"Created output directory: {output_dir}", log_path)
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            log_message(f"Created output directory: {output_dir}", log_path)
+        except OSError as e:
+            log_message(f"Error creating output directory {output_dir}: {e}", log_path)
+            raise
     else:
         log_message(f"Reusing existing output directory: {output_dir}", log_path)

--- a/scripts/log_utils.py
+++ b/scripts/log_utils.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+from datetime import datetime
 
 
-def log_message(message: str, log_path: Path) -> None:
+def log_message(message: str, log_path: Path | None = None) -> None:
     """
     Write a message to both stdout and append it to a log file.
 
@@ -9,9 +10,14 @@ def log_message(message: str, log_path: Path) -> None:
         message (str): The message to be logged.
         log_path (Path): The file path where the log should be saved.
     """
-    print(message)
-    with open(log_path, "a") as f:
-        f.write(message + "\n")
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    full_message = f"[{timestamp}] {message}"
+
+    print(full_message)  # always print to stdout
+
+    if log_path is not None:
+        with log_path.open("a") as f:
+            f.write(full_message + "\n")
 
 
 def check_required_file(file_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,3 +183,23 @@ def test_cli_mock_without_log(tmp_path, monkeypatch, capsys):
     assert "Simulating AlphaFold inference" in output.out
     assert "Mock inference complete" in output.out
 
+
+def test_cli_log_path_unwritable(tmp_path, monkeypatch):
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(">seq1\nACDEFG")
+
+    # simulate a log file that is unwritable
+    unwritable_log = tmp_path / "log_dir"
+    unwritable_log.mkdir()  # set unwritable log path as a directory
+
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner",
+        "--input", str(fasta_file),
+        "--backend", "mock",
+        "--log", str(unwritable_log)   
+    ])
+
+    # Act & Assert 
+    with pytest.raises(IsADirectoryError):  
+        main()
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,3 +163,23 @@ def test_cli_external_missing_af2_script(mock_subprocess_run, tmp_path, monkeypa
     # Act & Assert:
     with pytest.raises(ValueError, match="requires --af2-python and --af2-script"):
         main()
+
+
+def test_cli_mock_without_log(tmp_path, monkeypatch, capsys):
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(">Test sequence\nSEQUENCE")
+
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner", 
+        "--input", str(fasta_file), 
+        "--backend", "mock",
+    ])
+
+    # Act
+    main()
+    output = capsys.readouterr()
+
+    # Assert
+    assert "Simulating AlphaFold inference" in output.out
+    assert "Mock inference complete" in output.out
+

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -41,3 +41,17 @@ def test_prepare_output_dir_raises_if_parent_is_file(tmp_path):
 
     content = log_file.read_text()
     assert "Error creating output directory" in content
+
+
+def test_prepare_output_dir_logs_reuse_error_when_log_invalid(tmp_path, capsys):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    log_path = tmp_path / "badlog"
+    log_path.mkdir()
+
+    with pytest.raises(OSError):
+        prepare_output_dir(output_dir, log_path)
+        output = capsys.readouterr()
+        assert "Error reusing output directory" in output.out
+

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,6 +1,8 @@
-import shutil
+import pytest
+import pdb
 from scripts.io_utils import prepare_output_dir
 from pathlib import Path
+
 
 def test_prepare_output_dir_creates_folder(tmp_path):
     # Arrange
@@ -23,3 +25,19 @@ def test_prepare_output_dir_reuses_existing(tmp_path):
     prepare_output_dir(output_dir)
 
     assert dummy.exists()
+
+
+def test_prepare_output_dir_raises_if_parent_is_file(tmp_path):
+    # 模擬情境：output_dir 的 parent 是一個檔案 → 不能 mkdir
+    file_as_parent = tmp_path / "not_a_dir"
+    file_as_parent.write_text("I am a file")
+
+    # output_dir 嘗試在檔案底下建立 → 會失敗
+    output_dir = file_as_parent / "subdir"
+    log_file = tmp_path / "log.txt"
+
+    with pytest.raises(OSError):
+        prepare_output_dir(output_dir, log_file)
+
+    content = log_file.read_text()
+    assert "Error creating output directory" in content

--- a/tests/test_io_utils.py
+++ b/tests/test_io_utils.py
@@ -1,0 +1,25 @@
+import shutil
+from scripts.io_utils import prepare_output_dir
+from pathlib import Path
+
+def test_prepare_output_dir_creates_folder(tmp_path):
+    # Arrange
+    output_dir = tmp_path / "output"
+
+    # Act
+    prepare_output_dir(output_dir)
+
+    # Assert
+    assert output_dir.exists()
+    assert output_dir.is_dir()
+
+
+def test_prepare_output_dir_reuses_existing(tmp_path):
+    output_dir = tmp_path / "results"
+    output_dir.mkdir()
+    dummy = output_dir / "dummy.txt"
+    dummy.write_text("data")
+
+    prepare_output_dir(output_dir)
+
+    assert dummy.exists()


### PR DESCRIPTION
## 變更摘要

此 Pull Request 引入了新的實用函式，用於準備輸出目錄和記錄訊息，從而增強了 AlphaFold 執行器的功能。 它增加了 `scripts/io_utils.py`，其中包含一個用於建立或重複使用輸出目錄的函式，並修改了 `scripts/log_utils.py`，以在日誌訊息中包含時間戳記並處理可選的日誌路徑。 此外，它還在 `tests/test_cli.py` 和 `tests/test_io_utils.py` 中包含新的測試，以驗證新功能的行為。

### 重點

*   **輸出目錄準備**: `scripts/io_utils.py` 中的 `prepare_output_dir` 函式會建立輸出目錄（如果不存在），或者重複使用它（如果存在），並記錄所採取的動作。
*   **增強的日誌記錄**: `scripts/log_utils.py` 中的 `log_message` 函式現在在日誌訊息中包含時間戳記，並支援可選的檔案日誌記錄。
*   **CLI 測試**: 在 `tests/test_cli.py` 中新增了測試，以驗證 CLI 在沒有日誌檔案的模擬模式下運行時以及日誌路徑不可寫入時的行為。
*   **IO 實用程式測試**: 在 `tests/test_io_utils.py` 中新增了測試，以確保正確建立輸出目錄，並按預期重複使用現有目錄。

## 變更日誌

<details>
<summary>點擊此處以查看變更日誌</summary>

*   **scripts/io_utils.py**
    *   新增了一個新檔案 `scripts/io_utils.py`。
    *   引入了 `prepare_output_dir` 函式來處理輸出目錄的建立和重複使用。
    *   該函式接受輸出目錄路徑和可選的日誌路徑作為輸入。
    *   如果目錄不存在，則建立目錄並記錄建立，或者記錄正在重複使用現有目錄。
*   **scripts/log_utils.py**
    *   修改了 `log_message` 函式，以在日誌訊息中包含時間戳記。
    *   `log_message` 函式現在接受可選的 `log_path` 引數。
    *   如果提供了 `log_path`，則訊息會寫入指定的檔案；否則，只會列印到 stdout。
*   **tests/test_cli.py**
    *   新增了一個測試案例 `test_cli_mock_without_log`，以驗證 CLI 在沒有日誌檔案的模擬模式下的行為。
    *   新增了一個測試案例 `test_cli_log_path_unwritable`，以檢查日誌路徑不可寫入（例如，目錄）時 CLI 的反應。
*   **tests/test_io_utils.py**
    *   新增了一個新檔案 `tests/test_io_utils.py`。
    *   引入了 `test_prepare_output_dir_creates_folder`，以驗證在輸出目錄不存在時是否會建立該目錄。
    *   新增了 `test_prepare_output_dir_reuses_existing`，以確保重複使用現有輸出目錄而不會被清空。

</details>