### PR TITLE
feat: 新增摘要輸出功能及測試

### DIFF
--- a/fasta_inputs/1uao.fasta
+++ b/fasta_inputs/1uao.fasta
@@ -1,0 +1,2 @@
+>1UAO_1|Chain A|Chignolin|null
+GYDPETGTWG

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -6,6 +6,8 @@ from typing import NoReturn
 from scripts.env_utils import af_info, setup_platform
 from scripts.log_utils import check_required_file
 from scripts.inference import run_inference, run_alphafold_external
+from scripts.summary_utils import print_summary
+import pdb
 
 
 class CustomArgParser(argparse.ArgumentParser):
@@ -111,6 +113,15 @@ def main() -> None:
         )
     else:
         raise ValueError(f"Unknown backend: {args.backend}")
+
+    # Print a summary of the run
+    #print(f"[DEBUG] Current files: {[p.name for p in Path('.').iterdir()]}")
+    summary_path = Path("mock_output.json")
+    env_info_path = Path("af_info.json")
+
+    if summary_path.exists():
+        print()
+        print_summary(summary_path, env_info_path)
 
     # Log the successful setup
     print("Setup complete. Ready to run AlphaFold (not yet implemented).")

--- a/scripts/summary_utils.py
+++ b/scripts/summary_utils.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+def print_summary(summary_path: Path, env_path: Path | None = None) -> None:
+    """
+    Print a summary of inference results and optional environment info.
+
+    Parameters:
+        summary_path (Path): Path to JSON file with inference results.
+        env_path (Path | None): Optional path to environment info JSON.
+    """
+    if env_path and env_path.exists():
+        env_data = json.loads(env_path.read_text())
+        print("== Environment ==")
+        print(f"CUDA version: {env_data.get('cuda_version', 'N/A')}")
+        print(f"Driver version: {env_data.get('driver_version', 'N/A')}")
+        print(f"Python version: {env_data.get('python_version', 'N/A')}")
+        print(f"TensorFlow: {env_data.get('tensorflow_version', 'N/A')}")
+        print(f"JAX: {env_data.get('jax_version', 'N/A')}")
+        print(f"JAXlib: {env_data.get('jaxlib_version', 'N/A')}")
+        print()
+
+    data = json.loads(summary_path.read_text())
+    print("== Inference Summary ==")
+    print(f"Total sequences: {data.get('num_sequences', '?')}")
+    print(f"Total length: {data.get('total_sequence_length', '?')}")
+    print(f"MSA search: {data.get('msa', '?')} s")
+    print(f"Inference: {data.get('inference', '?')} s")
+    print(f"I/O + others: {data.get('io_others', '?')} s")
+    print(f"Model time: {data.get('model_times', [])}")
+    print(f"Wall time: {data.get('wall(hh:mm:ss)', '?')} ({data.get('wall(secs)', '?')} sec)")

--- a/tests/data/af_info.json
+++ b/tests/data/af_info.json
@@ -1,0 +1,8 @@
+{
+    "cuda_version": "12.4",
+    "driver_version": "545.23.08",
+    "python_version": "3.12.2",
+    "tensorflow_version": "2.17.1",
+    "jax_version": "0.4.29",
+    "jaxlib_version": "0.4.29+cuda12.cudnn91"
+}

--- a/tests/data/example_summary.json
+++ b/tests/data/example_summary.json
@@ -1,0 +1,9 @@
+{
+    "total_sequence_length": 51,
+    "num_sequences": 2,
+    "wall(hh:mm:ss)": "00:00:17",
+    "msa": 3.2,
+    "inference": 12.5,
+    "io_others": 1.7,
+    "model_times": [2.3, 2.5, 2.4, 2.6, 2.7]
+}

--- a/tests/data/mock_output.json
+++ b/tests/data/mock_output.json
@@ -1,0 +1,10 @@
+{
+    "total_sequence_length": 51,
+    "num_sequences": 2,
+    "msa": 3.2,
+    "inference": 12.5,
+    "io_others": 1.7,
+    "wall(hh:mm:ss)": "00:00:17",
+    "wall(secs)": 17.4,
+    "model_times": [2.3, 2.5, 2.4, 2.6, 2.7]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,3 +203,43 @@ def test_cli_log_path_unwritable(tmp_path, monkeypatch):
     with pytest.raises(IsADirectoryError):  
         main()
 
+
+def test_cli_summary_output(tmp_path, monkeypatch, capsys):
+    # 準備 input.fasta
+    example_fasta = Path("tests/data/single_seq.fasta")
+    fasta_text = example_fasta.read_text()
+    fasta_file = tmp_path / "input.fasta"
+    fasta_file.write_text(fasta_text)
+
+    # 預先建立模擬結果與環境資訊
+    example_summary = Path("tests/data/example_summary.json")
+    summary_text = example_summary.read_text()
+    summary = tmp_path / "mock_output.json"
+    summary.write_text(summary_text)
+
+    example_env = Path("tests/data/af_info.json")
+    env_text = example_env.read_text()
+    env_info_file = tmp_path / "af_info.json"
+    env_info_file.write_text(env_text)
+
+    # 指向 tmp_path 讓 CLI 找得到模擬檔案
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("sys.argv", [
+        "alphafold-runner",
+        "--input", str(fasta_file),
+        "--backend", "mock"
+    ])
+
+    main()
+
+    output = capsys.readouterr().out
+    assert (tmp_path / "mock_output.json").exists()
+    assert (tmp_path / "af_info.json").exists()
+    assert "== Inference Summary ==" in output
+    assert "Total sequences: 2" in output
+    assert "Total length: 51" in output
+    assert "Wall time: 00:00:17 (? sec)" in output
+
+    assert "== Environment ==" in output
+    assert "CUDA version: 12.4" in output
+    assert "JAXlib: 0.4.29+cuda12.cudnn91" in output

--- a/tests/test_summary_utils.py
+++ b/tests/test_summary_utils.py
@@ -1,0 +1,20 @@
+from scripts.summary_utils import print_summary
+from pathlib import Path
+import pdb
+
+def test_print_summary_outputs_expected_lines(tmp_path, capsys):
+    # Arrange
+    exmple_json = Path("tests/data") / "example_summary.json"
+    summary_text = exmple_json.read_text()
+    summary_json = tmp_path / "mock_output.json"
+    summary_json.write_text(summary_text)
+
+    # Act
+    print_summary(summary_json)
+
+    # Assert
+    output = capsys.readouterr().out
+    assert "== Inference Summary ==" in output
+    assert "Total sequences: 2" in output
+    assert "Total length: 51" in output
+    assert "Wall time: 00:00:17" in output


### PR DESCRIPTION
## 變更摘要

這個 Pull Request 為 AlphaFold 執行器引入了一項新的摘要輸出功能。它新增了一個 `print_summary` 函式，用於顯示來自 JSON 檔案的推論結果和環境資訊。主腳本經過修改，如果摘要和環境資訊檔案存在，則會呼叫此函式。此外，還新增了測試案例來驗證摘要輸出的功能，包括 CLI 整合的測試。

### 重點

*   **新功能：摘要輸出**：新增一個函式來列印推論結果和環境資訊的摘要。
*   **與主腳本整合**：修改主腳本，如果存在必要的 JSON 檔案，則呼叫摘要函式。
*   **測試**：包含新的測試，以確保摘要輸出如預期般工作，無論是通過 CLI 還是直接呼叫。

## 變更日誌

<details>
<summary>點擊此處以查看變更日誌</summary>

*   **fasta_inputs/1uao.fasta**
    *   新增一個用於測試的範例 FASTA 輸入檔案。
*   **scripts/main.py**
    *   從 `scripts/summary_utils.py` 匯入 `print_summary` 函式。
    *   在 `main` 函式中新增對 `print_summary` 的呼叫，如果 `mock_output.json` 和 `af_info.json` 存在，則顯示摘要。
    *   為方便除錯，新增一個 pdb 匯入。
*   **scripts/summary_utils.py**
    *   引入 `print_summary` 函式，以讀取和顯示來自 JSON 檔案的推論結果和環境資訊。
    *   該函式接收摘要和環境 JSON 檔案的路徑作為輸入。
    *   如果環境檔案存在，它會列印環境資訊 (CUDA、Driver、Python、TensorFlow、JAX 版本)。
    *   它會從摘要檔案中列印推論摘要 (總序列數、總長度、MSA 搜尋時間、推論時間、I/O 時間、模型時間和總耗用時間)。
*   **tests/data/af_info.json**
    *   建立一個 JSON 檔案，包含用於測試的模擬環境資訊。
*   **tests/data/example_summary.json**
    *   建立一個 JSON 檔案，包含用於測試的範例摘要資料。
*   **tests/data/mock_output.json**
    *   建立一個 JSON 檔案，包含用於測試的模擬輸出資料。
*   **tests/test_cli.py**
    *   新增一個測試案例 `test_cli_summary_output`，用於驗證在使用 'mock' 後端執行 CLI 時的摘要輸出。
    *   該測試會建立模擬摘要和環境檔案，執行 CLI，並斷言預期的摘要資訊已列印到控制台。
    *   該測試斷言模擬輸出和環境資訊檔案存在。
    *   該測試斷言輸出包含來自摘要和環境資訊的預期字串。
*   **tests/test_summary_utils.py**
    *   新增一個測試案例 `test_print_summary_outputs_expected_lines`，用於驗證 `print_summary` 函式的輸出。
    *   該測試建立一個模擬摘要 JSON 檔案，呼叫 `print_summary`，並斷言預期的行已列印到控制台。

</details>